### PR TITLE
fix(context): pagesGraph generation for same name beginnings

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -15,7 +15,9 @@ const contextPages = (
   const result = [];
   for (const item of items) {
     if (typeof item === "string") {
-      const page = pages.find((p) => p.input.startsWith(path.join(dir, item)));
+      const page = pages.find((p) =>
+        p.input.startsWith(path.join(dir, item) + "/")
+      );
       if (page) {
         page.nav = { key: item };
         if (parent) page.nav.parent = parent;


### PR DESCRIPTION
This is what I get when I have 2 components where the name beginning is the same, e.g. `accordion` and `accordion-item`

![image](https://user-images.githubusercontent.com/137844/138474214-442ccc01-f037-45fd-ba2d-eb1c8303fd1c.png)

which creates a wrong object for `accordion` containing data for `accordion-item`, because in the pages array the `accordion-item` comes first and matches with `startsWith('accordion')` :D